### PR TITLE
NF: GitHub access token

### DIFF
--- a/master/buildbot/status/web/hooks/github.py
+++ b/master/buildbot/status/web/hooks/github.py
@@ -282,5 +282,7 @@ def getChanges(request, options=None):
 
     handler = klass(options.get('secret', None),
                     options.get('strict', False),
-                    options.get('codebase', None))
+                    options.get('codebase', None),
+                    options.get('token', None),
+                    )
     return handler.process(request)


### PR DESCRIPTION
For a while, in busy hours I have spotted that buildbot failed to react to new changes being pushed to long outstanding PRs... apparently it is due to rate limiting of 60 requests/hour for non-authenticated connections.  And it is 5,000 for those authenticated  via a token.  So here is a patch for your branch which I thought might come handy for you too

I am still not sure if everything works as it should for status updates since it seems even though buildbot is running -- status doesn't get updated and I don't see obvious logs for that.
